### PR TITLE
Fix the 'mode' intrinsic lexer action

### DIFF
--- a/tool/src/org/antlr/v4/parse/ANTLRParser.g
+++ b/tool/src/org/antlr/v4/parse/ANTLRParser.g
@@ -642,8 +642,13 @@ lexerCommands
 	;
 
 lexerCommand
-	:	id LPAREN lexerCommandExpr RPAREN -> ^(LEXER_ACTION_CALL id lexerCommandExpr)
-	|	id
+	:	lexerCommandName LPAREN lexerCommandExpr RPAREN -> ^(LEXER_ACTION_CALL lexerCommandName lexerCommandExpr)
+	|	lexerCommandName
+	;
+
+lexerCommandName
+	:	id
+	|	MODE
 	;
 
 lexerCommandExpr

--- a/tool/src/org/antlr/v4/parse/ATNBuilder.g
+++ b/tool/src/org/antlr/v4/parse/ATNBuilder.g
@@ -113,10 +113,15 @@ lexerCommands returns [ATNFactory.Handle p]
     ;
 
 lexerCommand returns [String cmd]
-	:	^(LEXER_ACTION_CALL ID lexerCommandExpr)
-        {$cmd = factory.lexerCallCommand($ID, $lexerCommandExpr.start);}
-	|	ID
-        {$cmd = factory.lexerCommand($ID);}
+	:	^(LEXER_ACTION_CALL lexerCommandName lexerCommandExpr)
+		{$cmd = factory.lexerCallCommand($lexerCommandName.start, $lexerCommandExpr.start);}
+	|	lexerCommandName
+		{$cmd = factory.lexerCommand($lexerCommandName.start);}
+	;
+
+lexerCommandName
+	:	ID
+	|	MODE
 	;
 
 lexerCommandExpr

--- a/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
+++ b/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
@@ -414,10 +414,15 @@ alternative
     ;
 
 lexerCommand
-	:	^(LEXER_ACTION_CALL ID lexerCommandExpr)
-        {lexerCallCommand(currentOuterAltNumber, $ID, $lexerCommandExpr.start);}
-	|	ID
-        {lexerCommand(currentOuterAltNumber, $ID);}
+	:	^(LEXER_ACTION_CALL lexerCommandName lexerCommandExpr)
+		{lexerCallCommand(currentOuterAltNumber, $lexerCommandName.start, $lexerCommandExpr.start);}
+	|	lexerCommandName
+		{lexerCommand(currentOuterAltNumber, $lexerCommandName.start);}
+	;
+
+lexerCommandName
+	:	ID
+	|	MODE
 	;
 
 lexerCommandExpr

--- a/tool/test/org/antlr/v4/test/TestLexerExec.java
+++ b/tool/test/org/antlr/v4/test/TestLexerExec.java
@@ -119,6 +119,38 @@ public class TestLexerExec extends BaseTest {
 		assertEquals(expecting, found);
 	}
 
+	@Test public void testLexerPushPopModeAction() throws Exception {
+		String grammar =
+			"lexer grammar L;\n" +
+			"STRING_START : '\"' -> pushMode(STRING_MODE), more ;\n" +
+			"WS : (' '|'\n') -> skip ;\n"+
+			"mode STRING_MODE;\n"+
+			"STRING : '\"' -> popMode ;\n"+
+			"ANY : . -> more ;\n";
+		String found = execLexer("L.g", grammar, "L", "\"abc\" \"ab\"");
+		String expecting =
+			"[@0,0:4='\"abc\"',<5>,1:0]\n" +
+			"[@1,6:9='\"ab\"',<5>,1:6]\n" +
+			"[@2,10:9='<EOF>',<-1>,1:10]\n";
+		assertEquals(expecting, found);
+	}
+
+	@Test public void testLexerModeAction() throws Exception {
+		String grammar =
+			"lexer grammar L;\n" +
+			"STRING_START : '\"' -> mode(STRING_MODE), more ;\n" +
+			"WS : (' '|'\n') -> skip ;\n"+
+			"mode STRING_MODE;\n"+
+			"STRING : '\"' -> mode(DEFAULT_MODE) ;\n"+
+			"ANY : . -> more ;\n";
+		String found = execLexer("L.g", grammar, "L", "\"abc\" \"ab\"");
+		String expecting =
+			"[@0,0:4='\"abc\"',<5>,1:0]\n" +
+			"[@1,6:9='\"ab\"',<5>,1:6]\n" +
+			"[@2,10:9='<EOF>',<-1>,1:10]\n";
+		assertEquals(expecting, found);
+	}
+
 	@Test public void testKeywordID() throws Exception {
 		String grammar =
 			"lexer grammar L;\n"+


### PR DESCRIPTION
Fix the "mode(modeName)" intrinsic lexer action. Previously broken because "mode" is a keyword not an ID.
