### PR TITLE
Show lexer DFA stats in testPerformance

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -114,7 +114,7 @@ public class LexerATNSimulator extends ATNSimulator {
 	protected int charPositionInLine = 0;
 
 	@NotNull
-	protected DFA[] dfa;
+	public final DFA[] dfa;
 	protected int mode = Lexer.DEFAULT_MODE;
 
 	/** Used during DFA/ATN exec to record the most recent accept configuration info */

--- a/tool/test/org/antlr/v4/test/TestPerformance.java
+++ b/tool/test/org/antlr/v4/test/TestPerformance.java
@@ -284,6 +284,29 @@ public class TestPerformance extends BaseTest {
                           tokenCount,
                           System.currentTimeMillis() - startTime);
 
+		final LexerATNSimulator lexerInterpreter = sharedLexer.getInterpreter();
+		final DFA[] modeToDFA = lexerInterpreter.dfa;
+		if (SHOW_DFA_STATE_STATS) {
+			int states = 0;
+			int configs = 0;
+			Set<ATNConfig> uniqueConfigs = new HashSet<ATNConfig>();
+
+			for (int i = 0; i < modeToDFA.length; i++) {
+				DFA dfa = modeToDFA[i];
+				if (dfa == null || dfa.states == null) {
+					continue;
+				}
+
+				states += dfa.states.size();
+				for (DFAState state : dfa.states.values()) {
+					configs += state.configset.size();
+					uniqueConfigs.addAll(state.configset);
+				}
+			}
+
+			System.out.format("There are %d lexer DFAState instances, %d configs (%d unique).\n", states, configs, uniqueConfigs.size());
+		}
+
         if (RUN_PARSER) {
             // make sure the individual DFAState objects actually have unique ATNConfig arrays
             final ParserATNSimulator<?> interpreter = sharedParser.getInterpreter();
@@ -307,7 +330,7 @@ public class TestPerformance extends BaseTest {
 					}
                 }
 
-                System.out.format("There are %d DFAState instances, %d configs (%d unique).\n", states, configs, uniqueConfigs.size());
+                System.out.format("There are %d parser DFAState instances, %d configs (%d unique).\n", states, configs, uniqueConfigs.size());
             }
 
             int localDfaCount = 0;


### PR DESCRIPTION
Update `testPerformance` to show information about DFA states in the lexer
