### PR TITLE
Optimize empty listeners case

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -175,10 +175,17 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 
 	public void removeParseListener(ParseListener<Token> l) {
 		if ( l==null ) return;
-		if ( _parseListeners!=null ) _parseListeners.remove(l);
+		if ( _parseListeners!=null ) {
+			_parseListeners.remove(l);
+			if (_parseListeners.isEmpty()) {
+				_parseListeners = null;
+			}
+		}
 	}
 
-	public void removeParseListeners() { if ( _parseListeners!=null ) _parseListeners.clear(); }
+	public void removeParseListeners() {
+		_parseListeners = null;
+	}
 
 	public void triggerEnterRuleEvent() {
 		for (ParseListener<Token> l : _parseListeners) {


### PR DESCRIPTION
The parser is more efficient when `_parseListeners` is null as opposed to just empty, so set it to null when the last item is removed.
