### PR TITLE
Reduce number of locals declared in generated code

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -225,6 +225,9 @@ RuleFunction(currentRule,code,locals,ruleCtx,altLabelCtxs,namedActions,finallyAc
 	<namedActions.init>
 	<locals; separator="\n">
 	try {
+<if(currentRule.hasLookaheadBlock)>
+		int _alt;
+<endif>
 		<code>
 		_localctx.stop = _input.LT(-1);
 		<postamble; separator="\n">
@@ -258,6 +261,9 @@ LeftRecursiveRuleFunction(currentRule,code,locals,ruleCtx,altLabelCtxs,
 	<namedActions.init>
 	<locals; separator="\n">
 	try {
+<if(currentRule.hasLookaheadBlock)>
+		int _alt;
+<endif>
 		<code>
 		_localctx.stop = _input.LT(-1);
 		<postamble; separator="\n">
@@ -409,29 +415,27 @@ case <i>:
 }
 >>
 
-// TODO: we we need uniqueID? a single _alt might work
-
 StarBlock(choice, alts, sync, iteration) ::= <<
 setState(<choice.stateNumber>);
 _errHandler.sync(this);
-int _alt<choice.uniqueID> = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
-while ( _alt<choice.uniqueID>!=<choice.exitAlt> && _alt<choice.uniqueID>!=-1 ) {
-	if ( _alt<choice.uniqueID>==1 ) {
+_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
+while ( _alt!=<choice.exitAlt> && _alt!=-1 ) {
+	if ( _alt==1 ) {
 		<iteration>
 		<alts> <! should only be one !>
 	}
 	setState(<choice.loopBackStateNumber>);
 	_errHandler.sync(this);
-	_alt<choice.uniqueID> = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
+	_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
 }
 >>
 
 PlusBlock(choice, alts, error) ::= <<
 setState(<choice.blockStartStateNumber>); <! alt block decision !>
 _errHandler.sync(this);
-int _alt<choice.uniqueID> = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
+_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
 do {
-	switch ( _alt<choice.uniqueID> ) {
+	switch ( _alt ) {
 		<alts:{alt|
 case <i>:
 	<alt>
@@ -441,8 +445,8 @@ case <i>:
 	}
 	setState(<choice.loopBackStateNumber>); <! loopback/exit decision !>
 	_errHandler.sync(this);
-	_alt<choice.uniqueID> = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
-} while ( _alt<choice.uniqueID>!=<choice.exitAlt> && _alt<choice.uniqueID>!=-1 );
+	_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
+} while ( _alt!=<choice.exitAlt> && _alt!=-1 );
 >>
 
 Sync(s) ::= "sync(<s.expecting.name>);"

--- a/tool/src/org/antlr/v4/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelController.java
@@ -274,6 +274,7 @@ public class OutputModelController {
 		try {
 			// walk AST of rule alts/elements
 			function.code = DefaultOutputModelFactory.list(walker.block(null, null));
+			function.hasLookaheadBlock = walker.hasLookaheadBlock;
 		}
 		catch (org.antlr.runtime.RecognitionException e){
 			e.printStackTrace(System.err);

--- a/tool/src/org/antlr/v4/codegen/SourceGenTriggers.g
+++ b/tool/src/org/antlr/v4/codegen/SourceGenTriggers.g
@@ -47,6 +47,7 @@ import java.util.HashMap;
 
 @members {
 	public OutputModelController controller;
+    public boolean hasLookaheadBlock;
     public SourceGenTriggers(TreeNodeStream input, OutputModelController controller) {
     	this(input);
     	this.controller = controller;
@@ -66,7 +67,9 @@ block[GrammarAST label, GrammarAST ebnfRoot] returns [List<? extends SrcOp> omos
     	    $omos = DefaultOutputModelFactory.list(controller.getChoiceBlock((BlockAST)$blk, alts, $label));
     	}
     	else {
-    	    $omos = DefaultOutputModelFactory.list(controller.getEBNFBlock($ebnfRoot, alts));
+            Choice choice = controller.getEBNFBlock($ebnfRoot, alts);
+            hasLookaheadBlock |= choice instanceof PlusBlock || choice instanceof StarBlock;
+    	    $omos = DefaultOutputModelFactory.list(choice);
     	}
     	}
     ;
@@ -132,6 +135,7 @@ subrule returns [List<? extends SrcOp> omos]
 		alt.addOp(blk);
 		alts.add(alt);
 		SrcOp loop = controller.getEBNFBlock($op, alts); // "star it"
+        hasLookaheadBlock |= loop instanceof PlusBlock || loop instanceof StarBlock;
    	    $omos = DefaultOutputModelFactory.list(loop);
 		}
 	| 	block[null, null]					{$omos = $block.omos;}

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -76,6 +76,7 @@ public class RuleFunction extends OutputModelObject {
 	public Collection<Attribute> args = null;
 	public Rule rule;
 	public AltLabelStructDecl[] altToContext;
+	public boolean hasLookaheadBlock;
 
 	@ModelElement public List<SrcOp> code;
 	@ModelElement public OrderedHashSet<Decl> locals; // TODO: move into ctx?


### PR DESCRIPTION
Use single `int _alt` in generated code instead of a new `_alt<choice.uniqueID>` for each `PlusBlock` and `StarBlock`.
