### PR TITLE
FailedPredicateException message

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/FailedPredicateException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/FailedPredicateException.java
@@ -46,13 +46,13 @@ public class FailedPredicateException extends RecognitionException {
 		this(recognizer, null);
 	}
 
-	public FailedPredicateException(Parser recognizer, @Nullable String msg) {
+	public FailedPredicateException(Parser recognizer, @Nullable String predicate) {
 		super(recognizer, recognizer.getInputStream(), recognizer._ctx);
 		ATNState s = recognizer.getInterpreter().atn.states.get(recognizer._ctx.s);
 		PredicateTransition trans = (PredicateTransition)s.transition(0);
 		ruleIndex = trans.ruleIndex;
 		predIndex = trans.predIndex;
-		this.msg = msg;
+		this.msg = String.format("failed predicate: {%s}?", predicate);
 		Token la = recognizer.getCurrentToken();
 		this.offendingToken = la;
 	}

--- a/tool/src/org/antlr/v4/codegen/model/SemPred.java
+++ b/tool/src/org/antlr/v4/codegen/model/SemPred.java
@@ -50,7 +50,10 @@ public class SemPred extends Action {
 		GrammarAST failNode = ((PredAST)ast).getOption("fail");
 		CodeGenerator gen = factory.getGenerator();
 		if ( failNode==null ) {
-			msg = "failed predicate: "+ast.getText();
+			msg = ast.getText();
+			if (msg.startsWith("{") && msg.endsWith("}?")) {
+				msg = msg.substring(1, msg.length() - 2);
+			}
 			msg = gen.target.getTargetStringLiteralFromString(msg);
 			return;
 		}


### PR DESCRIPTION
Reduce size of generated code by emitting predicate text instead of full failed predicate message. Full message is constructed with `String.format` in the `FailedPredicateException` constructor.
