### PR TITLE
Default error listener

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ConsoleErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ConsoleErrorListener.java
@@ -1,0 +1,49 @@
+/*
+ [The "BSD license"]
+  Copyright (c) 2012 Terence Parr
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.runtime;
+
+/**
+ *
+ * @author Sam Harwell
+ */
+public class ConsoleErrorListener implements ANTLRErrorListener<Object> {
+	public static final ConsoleErrorListener INSTANCE = new ConsoleErrorListener();
+
+	@Override
+	public <T extends Object> void error(Recognizer<T, ?> recognizer,
+										T offendingSymbol,
+										int line,
+										int charPositionInLine,
+										String msg,
+										RecognitionException e)
+	{
+		System.err.println("line " + line + ":" + charPositionInLine + " " + msg);
+	}
+
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -310,14 +310,8 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		String msg = "token recognition error at: '"+
 			_input.substring(_tokenStartCharIndex, _input.index())+"'";
 		List<? extends ANTLRErrorListener<? super Integer>> listeners = getErrorListeners();
-		if ( listeners.isEmpty() ) {
-			System.err.println("line "+ _tokenStartLine +":"+
-							   _tokenStartCharPositionInLine +" "+
-							   msg);
-			return;
-		}
-		for (ANTLRErrorListener<? super Integer> pl : listeners) {
-			pl.error(this, null, _tokenStartLine, _tokenStartCharPositionInLine, msg, e);
+		for (ANTLRErrorListener<? super Integer> listener : listeners) {
+			listener.error(this, null, _tokenStartLine, _tokenStartCharPositionInLine, msg, e);
 		}
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -281,12 +281,8 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 			charPositionInLine = ((Token) offendingToken).getCharPositionInLine();
 		}
 		List<? extends ANTLRErrorListener<? super Token>> listeners = getErrorListeners();
-		if ( listeners.isEmpty() ) {
-			System.err.println("line "+line+":"+charPositionInLine+" "+msg);
-			return;
-		}
-		for (ANTLRErrorListener<? super Token> pl : listeners) {
-			pl.error(this, offendingToken, line, charPositionInLine, msg, e);
+		for (ANTLRErrorListener<? super Token> listener : listeners) {
+			listener.error(this, offendingToken, line, charPositionInLine, msg, e);
 		}
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
@@ -35,13 +35,15 @@ import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.misc.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 	public static final int EOF=-1;
 
-	private List<ANTLRErrorListener<? super Symbol>> _listeners;
+	@NotNull
+	private List<ANTLRErrorListener<? super Symbol>> _listeners =
+		new CopyOnWriteArrayList<ANTLRErrorListener<? super Symbol>>() {{ add(ConsoleErrorListener.INSTANCE); }};
 
 	protected ATNInterpreter _interp;
 
@@ -94,25 +96,27 @@ public abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 		return "'"+s+"'";
 	}
 
-	public void addErrorListener(ANTLRErrorListener<? super Symbol> pl) {
-		if ( _listeners ==null ) {
-			_listeners =
-				Collections.synchronizedList(new ArrayList<ANTLRErrorListener<? super Symbol>>(2));
-		}
-		if ( pl!=null ) _listeners.add(pl);
-	}
-
-	public void removeErrorListener(ANTLRErrorListener<? super Symbol> pl) {
-		if ( _listeners!=null ) _listeners.remove(pl);
-	}
-
-	public void removeErrorListeners() { if ( _listeners!=null ) _listeners.clear(); }
-
-	public @NotNull List<? extends ANTLRErrorListener<? super Symbol>> getErrorListeners() {
-		if (_listeners == null) {
-			return Collections.emptyList();
+	/**
+	 * @throws NullPointerException if {@code listener} is {@code null}.
+	 */
+	public void addErrorListener(@NotNull ANTLRErrorListener<? super Symbol> listener) {
+		if (listener == null) {
+			throw new NullPointerException("listener cannot be null.");
 		}
 
+		_listeners.add(listener);
+	}
+
+	public void removeErrorListener(@NotNull ANTLRErrorListener<? super Symbol> listener) {
+		_listeners.remove(listener);
+	}
+
+	public void removeErrorListeners() {
+		_listeners.clear();
+	}
+
+	@NotNull
+	public List<? extends ANTLRErrorListener<? super Symbol>> getErrorListeners() {
 		return new ArrayList<ANTLRErrorListener<? super Symbol>>(_listeners);
 	}
 


### PR DESCRIPTION
This modification resulted from problems I had trying to ignore parse errors. Before this patch, the only way to disable the output was to create a dummy `ANTLRErrorListener` implementation and add an instance of it via `Recognizer.addErrorListener`. Now output can be suppressed by simply calling `Recognizer.removeErrorListeners()` on a newly created recognizer.
### Patch summary:
- `Recognizer._listeners` initialized to have a single `ConsoleErrorListener`
- Use `CopyOnWriteArrayList` so listeners can be added/removed in callbacks
- Remove special handling for `_listeners` null or empty (never null, `ConsoleErrorListener` will be present if feature is desired)
