### PR TITLE
Loops recursion test

### DIFF
--- a/tool/test/org/antlr/v4/test/TestParserExec.java
+++ b/tool/test/org/antlr/v4/test/TestParserExec.java
@@ -214,40 +214,4 @@ public class TestParserExec extends BaseTest {
 		assertNull(this.stderrDuringParse);
 	}
 
-	/**
-	 *  Tests predictions for the following case involving closures.
-	 *  http://www.antlr.org/wiki/display/~admin/2011/12/29/Flaw+in+ANTLR+v3+LL(*)+analysis+algorithm
-	 */
-	@Test
-	public void testLoopsSimulateTailRecursion() throws Exception {
-		String grammar =
-			"grammar T;\n" +
-			"prog: expr_or_assign*;\n" +
-			"expr_or_assign\n" +
-			"    :   expr '++'\n" +
-			"    |   expr\n" +
-			"    ;\n" +
-			"expr: expr_primary ('<-' ID)? ;\n" +
-			"expr_primary\n" +
-			"    : '(' ID ')'\n" +
-			"    | ID '(' ID ')'\n" +
-			"    | ID\n" +
-			"    ;\n" +
-			"ID  : [a-z]+ ;\n" +
-			"\n" +
-			"\n" +
-			"\n" +
-			"";
-
-		String found = execParser("T.g", grammar, "TParser", "TLexer", "prog", "a(i)<-x", true);
-		assertEquals("", found);
-
-		String expecting =
-				"line 1:4 reportAttemptingFullContext d=1: [(31,1,[23 15 8]), (37,1,[23 15 8]), (45,1,[23 15 8]), (31,2,[23 19 8]), (37,2,[23 19 8]), (45,2,[23 19 8])], input='a(i)<-'\n" +
-				"line 1:7 reportContextSensitivity d=1: [(49,2,[])],uniqueAlt=2, input='a(i)<-x'\n" +
-				"line 1:3 reportAttemptingFullContext d=3: [(31,1,[23 19 8]), (37,2,[23 19 8]), (45,3,[23 19 8])], input='a(i)'\n" +
-				"line 1:7 reportAmbiguity d=3: ambigAlts={2..3}:[(49,2,[]), (49,3,[])],conflictingAlts={2..3}, input='a(i)<-x'\n";
-		assertEquals(expecting, this.stderrDuringParse);
-	}
-
 }


### PR DESCRIPTION
Adds a test for the `loopsSimulateTailRecursion` flag.

See also [Flaw in ANTLR v3 LL(_) analysis algorithm](http://www.antlr.org/wiki/display/~admin/2011/12/29/Flaw+in+ANTLR+v3+LL(_)+analysis+algorithm).
