### PR TITLE
Set stop token

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -386,6 +386,7 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	}
 
     public void exitRule() {
+		_ctx.stop = _input.LT(-1);
         // trigger event on _ctx, before it reverts to parent
         if ( _parseListeners != null) triggerExitRuleEvent();
 		_ctx = (ParserRuleContext<Token>)_ctx.parent;
@@ -411,6 +412,7 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	}
 
 	public void unrollRecursionContexts(ParserRuleContext<Token> _parentctx) {
+		_ctx.stop = _input.LT(-1);
 		ParserRuleContext<Token> retctx = _ctx; // save current ctx (return value)
 
 		// unroll so _ctx is as it was before call to recursive method

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
@@ -109,6 +109,12 @@ public class ParserRuleContext<Symbol extends Token> extends RuleContext {
 	/** Set during parsing to identify which alt of rule parser is in. */
 	public int altNum;
 
+	/**
+	 * The exception which forced this rule to return. If the rule successfully
+	 * completed, this is {@code null}.
+	 */
+	public RecognitionException exception;
+
 	public ParserRuleContext() { }
 
 	/** COPY a ctx (I'm deliberately not using copy constructor) */

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -229,11 +229,11 @@ RuleFunction(currentRule,code,locals,ruleCtx,altLabelCtxs,namedActions,finallyAc
 		int _alt;
 <endif>
 		<code>
-		_localctx.stop = _input.LT(-1);
 		<postamble; separator="\n">
 		<namedActions.after>
 	}
 	catch (RecognitionException re) {
+		_localctx.exception = re;
 		_errHandler.reportError(this, re);
 		_errHandler.recover(this, re);
 	}
@@ -265,11 +265,11 @@ LeftRecursiveRuleFunction(currentRule,code,locals,ruleCtx,altLabelCtxs,
 		int _alt;
 <endif>
 		<code>
-		_localctx.stop = _input.LT(-1);
 		<postamble; separator="\n">
 		<namedActions.after>
 	}
 	catch (RecognitionException re) {
+		_localctx.exception = re;
 		_errHandler.reportError(this, re);
 		_errHandler.recover(this, re);
 	}


### PR DESCRIPTION
Set stop token even when `RecognitionException` occurs. Add `ParserRuleContext.exception` field to hold exception if one occurs. Resolves antlr/antlr4#49.
