### PR TITLE
Override getRuleIndex

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -45,18 +45,18 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	public class TraceListener implements ParseListener<Token> {
 		@Override
 		public void enterNonLRRule(ParserRuleContext<Token> ctx) {
-			System.out.println("enter   " + getRuleNames()[ctx.ruleIndex] + ", LT(1)=" + _input.LT(1).getText());
+			System.out.println("enter   " + getRuleNames()[ctx.getRuleIndex()] + ", LT(1)=" + _input.LT(1).getText());
 		}
 
 		@Override
 		public void exitEveryRule(ParserRuleContext<Token> ctx) {
-			System.out.println("exit    "+getRuleNames()[ctx.ruleIndex]+", LT(1)="+_input.LT(1).getText());
+			System.out.println("exit    "+getRuleNames()[ctx.getRuleIndex()]+", LT(1)="+_input.LT(1).getText());
 		}
 
 		@Override
 		public void visitTerminal(ParserRuleContext<Token> parent, Token token) {
 			System.out.println("consume "+token+" rule "+
-							   getRuleNames()[parent.ruleIndex]+
+							   getRuleNames()[parent.getRuleIndex()]+
 							   " alt="+parent.altNum);
 		}
 	}
@@ -380,7 +380,6 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	public void enterRule(ParserRuleContext<Token> localctx, int ruleIndex) {
 		_ctx = localctx;
 		_ctx.start = _input.LT(1);
-		_ctx.ruleIndex = ruleIndex;
 		if (_buildParseTrees) addContextToParseTree();
         if ( _parseListeners != null) triggerEnterRuleEvent();
 	}
@@ -407,7 +406,6 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	public void pushNewRecursionContext(ParserRuleContext<Token> localctx, int ruleIndex) {
 		_ctx = localctx;
 		_ctx.start = _input.LT(1);
-		_ctx.ruleIndex = ruleIndex;
 	}
 
 	public void unrollRecursionContexts(ParserRuleContext<Token> _parentctx) {

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
@@ -103,9 +103,6 @@ public class ParserRuleContext<Symbol extends Token> extends RuleContext {
 
 	public Symbol start, stop;
 
-	/** Set during parsing to identify which rule parser is in. */
-	public int ruleIndex;
-
 	/** Set during parsing to identify which alt of rule parser is in. */
 	public int altNum;
 
@@ -120,7 +117,6 @@ public class ParserRuleContext<Symbol extends Token> extends RuleContext {
 
 		this.start = ctx.start;
 		this.stop = ctx.stop;
-		this.ruleIndex = ctx.ruleIndex;
 	}
 
 	public ParserRuleContext(@Nullable ParserRuleContext<Symbol> parent, int invokingStateNumber, int stateNumber) {
@@ -288,9 +284,6 @@ public class ParserRuleContext<Symbol extends Token> extends RuleContext {
 
 	@Override
 	public int getChildCount() { return children!=null ? children.size() : 0; }
-
-	@Override
-	public int getRuleIndex() { return ruleIndex; }
 
 	@Override
 	public Interval getSourceInterval() {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -608,6 +608,7 @@ public static class <struct.name> extends <superClass><if(interfaces)> implement
 		super(parent, state);
 		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
 	}
+	@Override public int getRuleIndex() { return RULE_<struct.derivedFromName>; }
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
 	public <struct.name>() { }
 	public void copyFrom(<struct.name> ctx) {


### PR DESCRIPTION
Override `getRuleIndex` in generated context classes instead of manually tracking it as a field in `ParserRuleContext`. Saves 1 field per context object and slightly improves performance of `enterRule`.
