### PR TITLE
Abstract recognizers

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -117,7 +117,7 @@ Parser(parser, funcs, atn, sempredFuncs, superclass) ::= <<
 
 Parser_(parser, funcs, atn, sempredFuncs, ctor, extras, superclass) ::= <<
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
-public class <parser.name> extends <superclass> {
+public <if(parser.abstractRecognizer)>abstract <endif>class <parser.name> extends <superclass> {
 	<if(parser.tokens)>
 	public static final int
 		<parser.tokens:{k | <k>=<parser.tokens.(k)>}; separator=", ", wrap, anchor>;
@@ -713,7 +713,7 @@ import org.antlr.v4.runtime.misc.*;
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs) ::= <<
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
-public class <lexer.name> extends Lexer {
+public <if(lexer.abstractRecognizer)>abstract <endif>class <lexer.name> extends Lexer {
 	public static final int
 		<lexer.tokens:{k | <k>=<lexer.tokens.(k)>}; separator=", ", wrap, anchor>;
 	<rest(lexer.modes):{m| public static final int <m> = <i>;}; separator="\n">

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -116,6 +116,7 @@ public class Tool {
 	public boolean gen_listener = true;
 	public boolean gen_parse_listener = false;
 	public boolean gen_visitor = false;
+	public boolean abstract_recognizer = false;
 
     public static Option[] optionDefs = {
         new Option("outputDirectory",	"-o", OptionArgType.STRING, "specify output directory where all output is generated"),
@@ -133,6 +134,7 @@ public class Tool {
 		new Option("gen_parse_listener",  "-no-parse-listener", "don't generate parse listener (default)"),
 		new Option("gen_visitor",		"-visitor", "generate parse tree visitor"),
 		new Option("gen_visitor",		"-no-visitor", "don't generate parse tree visitor (default)"),
+		new Option("abstract_recognizer", "-abstract", "generate abstract recognizer classes"),
 
         new Option("saveLexer",			"-Xsave-lexer", "save temp lexer file created for combined grammars"),
         new Option("launch_ST_inspector", "-XdbgST", "launch StringTemplate visualizer on generated code"),

--- a/tool/src/org/antlr/v4/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Lexer.java
@@ -49,6 +49,7 @@ public class Lexer extends OutputModelObject {
 	public String[] tokenNames;
 	public Set<String> ruleNames;
 	public Collection<String> modes;
+	public boolean abstractRecognizer;
 
 	@ModelElement public SerializedATN atn;
 	@ModelElement public LinkedHashMap<Rule, RuleActionFunction> actionFuncs =
@@ -89,6 +90,7 @@ public class Lexer extends OutputModelObject {
             }
         }
 		ruleNames = g.rules.keySet();
+		abstractRecognizer = g.isAbstract();
 	}
 
 }

--- a/tool/src/org/antlr/v4/codegen/model/Parser.java
+++ b/tool/src/org/antlr/v4/codegen/model/Parser.java
@@ -47,6 +47,7 @@ public class Parser extends OutputModelObject {
 	public Set<String> ruleNames;
 	public Collection<Rule> rules;
 	public ParserFile file;
+	public boolean abstractRecognizer;
 
 	@ModelElement public List<RuleFunction> funcs = new ArrayList<RuleFunction>();
 	@ModelElement public SerializedATN atn;
@@ -89,5 +90,7 @@ public class Parser extends OutputModelObject {
 		} else {
 			superclass = new DefaultParserSuperClass();
 		}
+
+		abstractRecognizer = g.isAbstract();
 	}
 }

--- a/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
+++ b/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
@@ -74,6 +74,7 @@ public class BasicSemanticChecks extends GrammarTreeVisitor {
 				add("TokenLabelType");
 				add("superClass");
 				add("filter");
+				add("abstract");
 			}
 		};
 
@@ -83,6 +84,7 @@ public class BasicSemanticChecks extends GrammarTreeVisitor {
 				add("tokenVocab");
 				add("TokenLabelType");
 				add("superClass");
+				add("abstract");
 			}
 		};
 

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -362,6 +362,11 @@ public class Grammar implements AttributeResolver {
         return parent.getOutermostGrammar();
     }
 
+	public boolean isAbstract() {
+		return Boolean.parseBoolean(getOptionString("abstract"))
+			|| (tool != null && tool.abstract_recognizer);
+	}
+
     /** Get the name of the generated recognizer; may or may not be same
      *  as grammar name.
      *  Recognizer is TParser and TLexer from T if combined, else
@@ -377,9 +382,16 @@ public class Grammar implements AttributeResolver {
                 buf.append(g.name);
                 buf.append('_');
             }
+			if (isAbstract()) {
+				buf.append("Abstract");
+			}
             buf.append(name);
             qualifiedName = buf.toString();
         }
+		else if (isAbstract()) {
+			qualifiedName = "Abstract" + name;
+		}
+
         if ( isCombined() || (isLexer() && implicitLexer!=null) )
         {
             suffix = Grammar.getGrammarTypeToFileNameSuffix(getType());


### PR DESCRIPTION
Implement support for abstract grammars via the `abstract` grammar option and `-abstract` command line option. Resolves antlr/antlr4#36.
