### PR TITLE
TokenStreamRewriter tweaks

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/TokenStreamRewriter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/TokenStreamRewriter.java
@@ -170,7 +170,7 @@ public class TokenStreamRewriter {
 		lastRewriteTokenIndexes = new HashMap<String, Integer>();
 	}
 
-	public final TokenStream getSource() {
+	public final TokenStream getTokenStream() {
 		return tokens;
 	}
 

--- a/tool/test/org/antlr/v4/test/TestTokenStreamRewriter.java
+++ b/tool/test/org/antlr/v4/test/TestTokenStreamRewriter.java
@@ -163,7 +163,7 @@ public class TestTokenStreamRewriter extends BaseTest {
 		stream.fill();
 // replace 3 * 0 with 0
 
-		String result = tokens.getSource().getText();
+		String result = tokens.getTokenStream().getText();
 		String expecting = "x = 3 * 0;";
 		assertEquals(expecting, result);
 
@@ -198,7 +198,7 @@ public class TestTokenStreamRewriter extends BaseTest {
 		stream.fill();
 		TokenStreamRewriter tokens = new TokenStreamRewriter(stream);
 
-		String result = tokens.getSource().getText();
+		String result = tokens.getTokenStream().getText();
 		String expecting = "x = 3 * 0 + 2 * 0;";
 		assertEquals(expecting, result);
 


### PR DESCRIPTION
- Only need `TokenStream`. The implementation should provide access to tokens like `BufferedTokenStream` does, but such an implementation is not actually required to be derived from `BufferedTokenStream`.
- Add `TokenStreamRewriter.getSource()`.
- Remove `TokenStreamRewriter.getOriginalText()` since `rewriter.getSource().getText()` already provides the same feature in a clearer way.
