### PR TITLE
Simplify ParserRuleContext.toString

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
@@ -304,15 +304,15 @@ public class ParserRuleContext<Symbol extends Token> extends RuleContext {
 	public String toString(@NotNull Recognizer<?,?> recog, RuleContext stop) {
 		if ( recog==null ) return super.toString(recog, stop);
 		StringBuilder buf = new StringBuilder();
-		ParserRuleContext<?> p = this;
+		RuleContext p = this;
 		buf.append("[");
+		String[] ruleNames = recog.getRuleNames();
 		while ( p != null && p != stop ) {
-			ATN atn = recog.getATN();
-			ATNState s = atn.states.get(p.s);
-			String ruleName = recog.getRuleNames()[s.ruleIndex];
+			int ruleIndex = p.getRuleIndex();
+			String ruleName = ruleIndex >= 0 && ruleIndex < ruleNames.length ? ruleNames[ruleIndex] : Integer.toString(ruleIndex);
 			buf.append(ruleName);
 			if ( p.parent != null ) buf.append(" ");
-			p = (ParserRuleContext<?>)p.parent;
+			p = p.parent;
 		}
 		buf.append("]");
 		return buf.toString();


### PR DESCRIPTION
Simplify `ParserRuleContext.toString` by calling `RuleContext.getRuleIndex()`. This also removes dependencies on some of the inner workings of the ATN.
