### PR TITLE
Prefer RangeTransition to SetTransition

### DIFF
--- a/tool/src/org/antlr/v4/automata/LexerATNFactory.java
+++ b/tool/src/org/antlr/v4/automata/LexerATNFactory.java
@@ -34,7 +34,17 @@ import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.misc.CharSupport;
 import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNState;
+import org.antlr.v4.runtime.atn.ActionTransition;
+import org.antlr.v4.runtime.atn.AtomTransition;
+import org.antlr.v4.runtime.atn.NotSetTransition;
+import org.antlr.v4.runtime.atn.RangeTransition;
+import org.antlr.v4.runtime.atn.RuleStartState;
+import org.antlr.v4.runtime.atn.SetTransition;
+import org.antlr.v4.runtime.atn.TokensStartState;
+import org.antlr.v4.runtime.atn.Transition;
+import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
@@ -178,7 +188,15 @@ public class LexerATNFactory extends ParserATNFactory {
 			left.addTransition(new NotSetTransition(right, set));
 		}
 		else {
-			left.addTransition(new SetTransition(right, set));
+			Transition transition;
+			if (set.getIntervals().size() == 1) {
+				Interval interval = set.getIntervals().get(0);
+				transition = new RangeTransition(right, interval.a, interval.b);
+			} else {
+				transition = new SetTransition(right, set);
+			}
+
+			left.addTransition(transition);
 		}
 		associatedAST.atnState = left;
 		return new Handle(left, right);


### PR DESCRIPTION
`RangeTransition` is lighter than `SetTransition`, so it's used when a set has only one interval.
