### PR TITLE
Automatic context accessors detect closures

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -170,7 +170,19 @@ public class RuleFunction extends OutputModelObject {
 			FrequencySet<String> altFreq = getElementFrequenciesForAlt(ast);
 			for (GrammarAST t : refs) {
 				String refLabelName = t.getText();
-				if ( altFreq.count(t.getText())>1 ) needsList.add(refLabelName);
+				if (needsList.contains(refLabelName)) {
+					continue;
+				}
+
+				if ( altFreq.count(t.getText())>1 ) {
+					needsList.add(refLabelName);
+				}
+				else {
+					boolean inLoop = t.hasAncestor(CLOSURE) || t.hasAncestor(POSITIVE_CLOSURE);
+					if (inLoop) {
+						needsList.add(refLabelName);
+					}
+				}
 			}
 		}
 		Set<Decl> decls = new HashSet<Decl>();


### PR DESCRIPTION
This change affects the context class generated for rules like the following:

``` antlr
x : y* ;
z : y+ ;
```

Previously the automatically generated `XContext.y()` and `ZContext.y()` each returned `YContext`. The closures are now properly detected and the methods return `List<? extends YContext>`.
