### PR TITLE
Do not serialize edges from RuleStopState

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -174,17 +174,16 @@ public abstract class ATNSimulator {
 			p += 6;
 		}
 
-		if (atn.grammarType == ATN.LEXER) {
-			for (ATNState state : atn.states) {
-				for (int i = 0; i < state.getNumberOfTransitions(); i++) {
-					Transition t = state.transition(i);
-					if (!(t instanceof RuleTransition)) {
-						continue;
-					}
-
-					RuleTransition ruleTransition = (RuleTransition)t;
-					atn.ruleToStopState[ruleTransition.target.ruleIndex].addTransition(new EpsilonTransition(ruleTransition.followState));
+		// edges for rule stop states can be derived, so they aren't serialized
+		for (ATNState state : atn.states) {
+			for (int i = 0; i < state.getNumberOfTransitions(); i++) {
+				Transition t = state.transition(i);
+				if (!(t instanceof RuleTransition)) {
+					continue;
 				}
+
+				RuleTransition ruleTransition = (RuleTransition)t;
+				atn.ruleToStopState[ruleTransition.target.ruleIndex].addTransition(new EpsilonTransition(ruleTransition.followState));
 			}
 		}
 

--- a/tool/src/org/antlr/v4/automata/ATNSerializer.java
+++ b/tool/src/org/antlr/v4/automata/ATNSerializer.java
@@ -79,9 +79,10 @@ public class ATNSerializer {
 		else if ( g.getType()== ANTLRParser.PARSER ) data.add(ATN.PARSER);
 		else data.add(ATN.TREE_PARSER);
 		data.add(g.getMaxTokenType());
-		data.add(atn.states.size());
 		int nedges = 0;
+
 		// dump states, count edges and collect sets while doing so
+		data.add(atn.states.size());
 		for (ATNState s : atn.states) {
 			if ( s==null ) { // might be optimized away
 				data.add(ATNState.INVALID_TYPE);
@@ -95,7 +96,12 @@ public class ATNSerializer {
 			else if ( s instanceof BlockStartState ) {
 				data.add(((BlockStartState)s).endState.stateNumber);
 			}
-			nedges += s.getNumberOfTransitions();
+
+			if (s.getStateType() != ATNState.RULE_STOP) {
+				// the deserializer can trivially derive these edges, so there's no need to serialize them
+				nedges += s.getNumberOfTransitions();
+			}
+
 			for (int i=0; i<s.getNumberOfTransitions(); i++) {
 				Transition t = s.transition(i);
 				int edgeType = Transition.serializationTypes.get(t.getClass());
@@ -105,6 +111,7 @@ public class ATNSerializer {
 				}
 			}
 		}
+
 		int nrules = atn.ruleToStartState.length;
 		data.add(nrules);
 		for (int r=0; r<nrules; r++) {
@@ -117,6 +124,7 @@ public class ATNSerializer {
 				data.add(rule.actionIndex);
 			}
 		}
+
 		int nmodes = atn.modeToStartState.size();
 		data.add(nmodes);
 		if ( nmodes>0 ) {
@@ -124,6 +132,7 @@ public class ATNSerializer {
 				data.add(modeStartState.stateNumber);
 			}
 		}
+
 		int nsets = sets.size();
 		data.add(nsets);
 		for (IntervalSet set : sets) {
@@ -133,10 +142,19 @@ public class ATNSerializer {
 				data.add(I.b);
 			}
 		}
+
 		data.add(nedges);
 		int setIndex = 0;
 		for (ATNState s : atn.states) {
-			if ( s==null ) continue; // might be optimized away
+			if ( s==null ) {
+				// might be optimized away
+				continue;
+			}
+
+			if (s.getStateType() == ATNState.RULE_STOP) {
+				continue;
+			}
+
 			for (int i=0; i<s.getNumberOfTransitions(); i++) {
 				Transition t = s.transition(i);
 


### PR DESCRIPTION
These edges can (and now are) trivially derived during deserialization. Saves one edge (6 chars) in the serialized version of the ATN per rule invocation in the grammar.
