### PR TITLE
Updated Parser.consume to improve calls to listener methods

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -364,18 +364,23 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	public Token consume() {
 		Token o = getCurrentToken();
 		getInputStream().consume();
-		TerminalNode tnode = null;
-		if (_buildParseTrees) {
+		boolean hasListener = _parseListeners != null && !_parseListeners.isEmpty();
+		if (_buildParseTrees || hasListener) {
 			if ( _errHandler.inErrorRecoveryMode(this) ) {
-				tnode = _ctx.addErrorNode(o);
+				ErrorNode<Token> node = _ctx.addErrorNode(o);
+				if (_parseListeners != null) {
+					for (ParseTreeListener<Token> listener : _parseListeners) {
+						listener.visitErrorNode(node);
+					}
+				}
 			}
 			else {
-				tnode = _ctx.addChild(o);
-			}
-		}
-		if ( _parseListeners != null) {
-			for (ParseTreeListener<Token> l : _parseListeners) {
-				l.visitTerminal(tnode);
+				TerminalNode<Token> node = _ctx.addChild(o);
+				if (_parseListeners != null) {
+					for (ParseTreeListener<Token> listener : _parseListeners) {
+						listener.visitTerminal(node);
+					}
+				}
 			}
 		}
 		return o;


### PR DESCRIPTION
Make sure to call `visitErrorNode` instead of `visitTerminal` when you have an `ErrorNode`. Also fix listener calls for case where `_buildParseTrees` is `false` (adds terminal as children of the rule nodes but won't actually construct the parse tree).
