### PR TITLE
Fix code generation issues with not set and wildcard transitions

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -142,7 +142,7 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 	 */
 	public Token match(int ttype) throws RecognitionException {
 		Token t = getCurrentToken();
-		if ( getInputStream().LA(1)==ttype ) {
+		if ( t.getType()==ttype ) {
 			_errHandler.endErrorCondition(this);
 			consume();
 		}
@@ -154,6 +154,24 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator<Token>
 				_ctx.addErrorNode(t);
 			}
 		}
+		return t;
+	}
+
+	public Token matchWildcard() throws RecognitionException {
+		Token t = getCurrentToken();
+		if (t.getType() > 0) {
+			_errHandler.endErrorCondition(this);
+			consume();
+		}
+		else {
+			t = _errHandler.recoverInline(this);
+			if (_buildParseTrees && t.getTokenIndex() == -1) {
+				// we must have conjured up a new token during single token insertion
+				// if it's not the current symbol
+				_ctx.addErrorNode(t);
+			}
+		}
+
 		return t;
 	}
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -450,7 +450,7 @@ CommonSetStuff(m, expr, capture, invert) ::= <<
 setState(<m.stateNumber>);
 <if(m.labels)><m.labels:{l | <labelref(l)> = }><endif>_input.LT(1);
 <capture>
-if ( <if(!invert)>!<endif>(<expr>) ) {
+if ( <if(invert)><m.varName> \<= 0 || <else>!<endif>(<expr>) ) {
 	<if(m.labels)><m.labels:{l | <labelref(l)> = (Token)}><endif>_errHandler.recoverInline(this);
 }
 consume();
@@ -458,7 +458,7 @@ consume();
 
 Wildcard(w) ::= <<
 setState(<w.stateNumber>);
-<if(w.labels)><w.labels:{l | <labelref(l)> = }><endif>_input.LT(1); consume();
+<if(w.labels)><w.labels:{l | <labelref(l)> = }><endif>matchWildcard();
 >>
 
 // ACTION STUFF

--- a/tool/src/org/antlr/v4/codegen/model/MatchNotSet.java
+++ b/tool/src/org/antlr/v4/codegen/model/MatchNotSet.java
@@ -33,6 +33,7 @@ import org.antlr.v4.codegen.OutputModelFactory;
 import org.antlr.v4.tool.ast.GrammarAST;
 
 public class MatchNotSet extends MatchSet {
+	public String varName = "_la";
 	public MatchNotSet(OutputModelFactory factory, GrammarAST ast) {
 		super(factory, ast);
 	}


### PR DESCRIPTION
Fix codegen problem where notset and wildcard transitions could match invalid tokens and/or EOF
