### PR TITLE
TerminalNodeImpl.getSourceInterval didn't fulfill the contract of SyntaxTree

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/tree/SyntaxTree.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/SyntaxTree.java
@@ -30,6 +30,7 @@
 package org.antlr.v4.runtime.tree;
 
 import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.NotNull;
 
 /** A tree that knows about an interval in a token stream
  *  is some kind of syntax tree. Subinterfaces distinguish
@@ -37,11 +38,11 @@ import org.antlr.v4.runtime.misc.Interval;
  */
 public interface SyntaxTree extends Tree {
 	/** Return an interval indicating the index in the TokenStream of
-	 *  the 1st and last token associated with this subtree. If this
+	 *  the first and last token associated with this subtree. If this
 	 *  node is a leaf, then the interval represents a single token.
-	 *
-	 *  If source interval is unknown, this does not return null.
-	 *  It returns Interval.INVALID.
+	 * <p/>
+	 *  If source interval is unknown, this returns {@link Interval#INVALID}.
 	 */
+	@NotNull
 	Interval getSourceInterval();
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
@@ -56,7 +56,8 @@ public class TerminalNodeImpl<Symbol extends Token> implements TerminalNode<Symb
 	public Interval getSourceInterval() {
 		if ( symbol ==null ) return Interval.INVALID;
 
-		return new Interval(symbol.getStartIndex(), symbol.getStopIndex());
+		int tokenIndex = symbol.getTokenIndex();
+		return new Interval(tokenIndex, tokenIndex);
 	}
 
 	@Override


### PR DESCRIPTION
Fix `TerminalNodeImpl.getSourceInterval` - was returning the token position in the input char stream but needed to return the token index.
