### PR TITLE
Add back support for certain lexer properties

### DIFF
--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -107,7 +107,7 @@ public class Grammar implements AttributeResolver {
 
     public static Map<String, AttributeDict> grammarAndLabelRefTypeToScope =
         new HashMap<String, AttributeDict>() {{
-//            put("lexer:RULE_LABEL", Rule.predefinedLexerRulePropertiesDict);
+            put("lexer:RULE_LABEL", Rule.predefinedLexerRulePropertiesDict);
 //            put("lexer:LEXER_STRING_LABEL", Rule.predefinedLexerRulePropertiesDict);
 //			put("lexer:TOKEN_LABEL", AttributeDict.predefinedTokenDict);
             put("parser:RULE_LABEL", Rule.predefinedRulePropertiesDict);

--- a/tool/src/org/antlr/v4/tool/Rule.java
+++ b/tool/src/org/antlr/v4/tool/Rule.java
@@ -58,13 +58,13 @@ public class Rule implements AttributeResolver {
             add(new Attribute("ctx"));
         }};
 
-//    public static AttributeDict predefinedLexerRulePropertiesDict =
-//        new AttributeDict(AttributeDict.DictType.PREDEFINED_LEXER_RULE) {{
-//            add(new Attribute("text"));
-//            add(new Attribute("type"));
-//			add(new Attribute("channel"));
-//			add(new Attribute("mode"));
-//        }};
+    public static AttributeDict predefinedLexerRulePropertiesDict =
+        new AttributeDict(AttributeDict.DictType.PREDEFINED_LEXER_RULE) {{
+            add(new Attribute("text"));
+            add(new Attribute("type"));
+			add(new Attribute("channel"));
+			add(new Attribute("mode"));
+        }};
 
 	public static Set<String> validLexerCommands = new HashSet<String>() {{
 		// CALLS


### PR DESCRIPTION
A previous commit caused the tool to crash with a NullPointerException when action code at the end of a lexer rule contained `$text`, `$type`, `$channel`, or `$mode`.
