### PR TITLE
Simplify getReachableTarget

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ActionTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ActionTransition.java
@@ -58,6 +58,11 @@ public final class ActionTransition extends Transition {
 	}
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return false;
+	}
+
+	@Override
 	public String toString() {
 		return "action_"+ruleIndex+":"+actionIndex;
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/AtomTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/AtomTransition.java
@@ -52,6 +52,11 @@ public final class AtomTransition extends Transition {
 	public IntervalSet label() { return IntervalSet.of(label); }
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return label == symbol;
+	}
+
+	@Override
 	@NotNull
 	public String toString() {
 		return String.valueOf(label);

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/EpsilonTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/EpsilonTransition.java
@@ -43,6 +43,11 @@ public final class EpsilonTransition extends Transition {
 	public boolean isEpsilon() { return true; }
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return false;
+	}
+
+	@Override
 	@NotNull
 	public String toString() {
 		return "epsilon";

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -464,66 +464,11 @@ public class LexerATNSimulator extends ATNSimulator {
 
 	@Nullable
 	public ATNState getReachableTarget(Transition trans, int t) {
-		switch (trans.getSerializationType()) {
-		case Transition.ATOM:
-			AtomTransition at = (AtomTransition)trans;
-			if ( at.label == t ) {
-				if ( debug ) {
-					System.out.format("match %s\n", getTokenName(at.label));
-				}
-
-				return at.target;
-			}
-
-			return null;
-
-		case Transition.RANGE:
-			RangeTransition rt = (RangeTransition)trans;
-			if ( t>=rt.from && t<=rt.to ) {
-				if ( debug ) {
-					System.out.format("match range %s\n", rt);
-				}
-
-				return rt.target;
-			}
-
-			return null;
-
-		case Transition.SET:
-			SetTransition st = (SetTransition)trans;
-			if ( st.set.contains(t) ) {
-				if ( debug ) {
-					System.out.format("match set %s\n", st.set.toString(true));
-				}
-
-				return st.target;
-			}
-
-			return null;
-
-		case Transition.NOT_SET:
-			NotSetTransition nst = (NotSetTransition)trans;
-			if (!nst.set.contains(t) && t!=IntStream.EOF) // ~set doesn't not match EOF
-			{
-				if ( debug ) {
-					System.out.format("match ~set %s\n", nst.set.toString(true));
-				}
-
-				return nst.target;
-			}
-
-			return null;
-
-		case Transition.WILDCARD:
-			if (t != IntStream.EOF) {
-				return trans.target;
-			}
-
-			return null;
-
-		default:
-			return null;
+		if (trans.matches(t, Lexer.MIN_CHAR_VALUE, Lexer.MAX_CHAR_VALUE)) {
+			return trans.target;
 		}
+
+		return null;
 	}
 
 	/** Delete configs for alt following ci that have a wildcard edge but

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/NotSetTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/NotSetTransition.java
@@ -44,6 +44,13 @@ public final class NotSetTransition extends SetTransition {
 	}
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return symbol >= minVocabSymbol
+			&& symbol <= maxVocabSymbol
+			&& !super.matches(symbol, minVocabSymbol, maxVocabSymbol);
+	}
+
+	@Override
 	public String toString() {
 		return '~'+super.toString();
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -913,44 +913,11 @@ public class ParserATNSimulator extends ATNSimulator {
 
 	@Nullable
 	public ATNState getReachableTarget(@NotNull Transition trans, int ttype) {
-		switch (trans.getSerializationType()) {
-		case Transition.ATOM:
-			AtomTransition at = (AtomTransition)trans;
-			if ( at.label == ttype ) {
-				return at.target;
-			}
-			return null;
-
-		case Transition.SET:
-			SetTransition st = (SetTransition)trans;
-			if ( st.set.contains(ttype) ) {
-				return st.target;
-			}
-			return null;
-
-		case Transition.NOT_SET:
-			NotSetTransition nst = (NotSetTransition)trans;
-			if ( !nst.set.contains(ttype) ) {
-				return nst.target;
-			}
-			return null;
-
-		case Transition.RANGE:
-			RangeTransition rt = (RangeTransition)trans;
-			if ( ttype>=rt.from && ttype<=rt.to ) {
-				return rt.target;
-			}
-			return null;
-
-		case Transition.WILDCARD:
-			if (ttype != Token.EOF) {
-				return trans.target;
-			}
-			return null;
-
-		default:
-			return null;
+		if (trans.matches(ttype, 0, atn.maxTokenType)) {
+			return trans.target;
 		}
+
+		return null;
 	}
 
 	public SemanticContext[] getPredsForAmbigAlts(@NotNull BitSet ambigAlts,

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/PredicateTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/PredicateTransition.java
@@ -57,6 +57,11 @@ public final class PredicateTransition extends Transition {
 	@Override
 	public boolean isEpsilon() { return true; }
 
+	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return false;
+	}
+
     public SemanticContext.Predicate getPredicate() {
    		return new SemanticContext.Predicate(ruleIndex, predIndex, isCtxDependent);
    	}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/RangeTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/RangeTransition.java
@@ -52,6 +52,11 @@ public final class RangeTransition extends Transition {
 	public IntervalSet label() { return IntervalSet.of(from, to); }
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return symbol >= from && symbol <= to;
+	}
+
+	@Override
 	@NotNull
 	public String toString() {
 		return "'"+(char)from+"'..'"+(char)to+"'";

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/RuleTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/RuleTransition.java
@@ -56,4 +56,9 @@ public final class RuleTransition extends Transition {
 
 	@Override
 	public boolean isEpsilon() { return true; }
+
+	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return false;
+	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/SetTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/SetTransition.java
@@ -56,6 +56,11 @@ public class SetTransition extends Transition {
 	public IntervalSet label() { return set; }
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return set.contains(symbol);
+	}
+
+	@Override
 	@NotNull
 	public String toString() {
 		return set.toString();

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/Transition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/Transition.java
@@ -110,4 +110,6 @@ public abstract class Transition {
 
 	@Nullable
 	public IntervalSet label() { return null; }
+
+	public abstract boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol);
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/WildcardTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/WildcardTransition.java
@@ -40,6 +40,11 @@ public final class WildcardTransition extends Transition {
 	}
 
 	@Override
+	public boolean matches(int symbol, int minVocabSymbol, int maxVocabSymbol) {
+		return symbol >= minVocabSymbol && symbol <= maxVocabSymbol;
+	}
+
+	@Override
 	@NotNull
 	public String toString() {
 		return ".";


### PR DESCRIPTION
This change factors code to simplify `ParserATNSimulator.getReachableTarget` and `LexerATNSimulator.getReachableTarget`.
