### PR TITLE
Add ParseCancellationException

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/BailErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BailErrorStrategy.java
@@ -29,14 +29,16 @@
 
 package org.antlr.v4.runtime;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
 /** Bail out of parser at first syntax error. Do this to use it:
  *  <p/>
  *  {@code myparser.setErrorHandler(new BailErrorStrategy());}
  */
 public class BailErrorStrategy extends DefaultErrorStrategy {
     /** Instead of recovering from exception {@code e}, re-throw it wrapped
-     *  in a generic {@link RuntimeException} so it is not caught by the
-     *  rule function catches.  Use {@link RuntimeException#getCause()} to get the
+     *  in a {@link ParseCancellationException} so it is not caught by the
+     *  rule function catches.  Use {@link Exception#getCause()} to get the
 	 *  original {@link RecognitionException}.
      */
     @Override
@@ -45,7 +47,7 @@ public class BailErrorStrategy extends DefaultErrorStrategy {
 			context.exception = e;
 		}
 
-        throw new RuntimeException(e);
+        throw new ParseCancellationException(e);
     }
 
     /** Make sure we don't attempt to recover inline; if the parser
@@ -60,7 +62,7 @@ public class BailErrorStrategy extends DefaultErrorStrategy {
 			context.exception = e;
 		}
 
-        throw new RuntimeException(e);
+        throw new ParseCancellationException(e);
     }
 
     /** Make sure we don't attempt to recover from problems in subrules. */

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/ParseCancellationException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/ParseCancellationException.java
@@ -1,0 +1,64 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2011 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.runtime.misc;
+
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.RecognitionException;
+
+import java.util.concurrent.CancellationException;
+
+/**
+ * This exception is thrown to cancel a parsing operation. This exception does
+ * not extend {@link RecognitionException}, allowing it to bypass the standard
+ * error recovery mechanisms. {@link BailErrorStrategy} throws this exception in
+ * response to a parse error.
+ *
+ * @author Sam Harwell
+ */
+public class ParseCancellationException extends CancellationException {
+
+	public ParseCancellationException() {
+	}
+
+	public ParseCancellationException(String message) {
+		super(message);
+	}
+
+	public ParseCancellationException(Throwable cause) {
+		initCause(cause);
+	}
+
+	public ParseCancellationException(String message, Throwable cause) {
+		super(message);
+		initCause(cause);
+	}
+
+}


### PR DESCRIPTION
Create a new `ParseCancellationException` for `BailErrorStrategy`. Derived from `RuntimeException` (which `BailErrorStrategy` previously used) so existing handlers will still work.
