### PR TITLE
Move initialization of finallyAction to fillNamedActions

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -125,7 +125,6 @@ public class RuleFunction extends OutputModelObject {
 				exceptions.add(new ExceptionClause(factory, catchArg, catchAction));
 			}
 		}
-		if ( r.finallyAction!=null ) finallyAction = new Action(factory, r.finallyAction);
 
 		startState = factory.getGrammar().atn.ruleToStartState[r.index];
 	}
@@ -157,6 +156,10 @@ public class RuleFunction extends OutputModelObject {
 	}
 
 	public void fillNamedActions(OutputModelFactory factory, Rule r) {
+		if ( r.finallyAction!=null ) {
+			finallyAction = new Action(factory, r.finallyAction);
+		}
+
 		namedActions = new HashMap<String, Action>();
 		for (String name : r.namedActions.keySet()) {
 			ActionAST ast = r.namedActions.get(name);

--- a/tool/test/org/antlr/v4/test/TestActionTranslation.java
+++ b/tool/test/org/antlr/v4/test/TestActionTranslation.java
@@ -124,15 +124,13 @@ public class TestActionTranslation extends BaseTest {
 
 	@Test public void testRefToTextAttributeForCurrentRule() throws Exception {
         String action = "$a.text; $text";
+
+		// this is the expected translation for all cases
 		String expected =
 			"_input.getText(_localctx.start, _input.LT(-1)); _input.getText(_localctx.start, _input.LT(-1))";
+
 		testActions(attributeTemplate, "init", action, expected);
-		expected =
-			"_input.getText(_localctx.start, _input.LT(-1)); _input.getText(_localctx.start, _input.LT(-1))";
 		testActions(attributeTemplate, "inline", action, expected);
-		expected =
-			"(_localctx.a!=null?_input.getText(_localctx.a.start,_localctx.a.stop):null);" +
-			" _input.getText(_localctx.start, _input.LT(-1))";
 		testActions(attributeTemplate, "finally", action, expected);
     }
 


### PR DESCRIPTION
Move initialization of `finallyAction` to `fillNamedActions` - factory cannot provide context information for the `Action` construction before the constructor completes. Fixes code generation for `$a.text` in the following:

``` antlr
a : stuff
  ;
  finally{System.out.println($a.text);}
```
