### PR TITLE
SLL predicate evaluation

### DIFF
--- a/tool/test/org/antlr/v4/test/TestParserExec.java
+++ b/tool/test/org/antlr/v4/test/TestParserExec.java
@@ -1,6 +1,5 @@
 package org.antlr.v4.test;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /** Test parser execution.
@@ -231,21 +230,6 @@ public class TestParserExec extends BaseTest {
 	/**
 	 * This test is meant to test the expected solution to antlr/antlr4#42.
 	 * https://github.com/antlr/antlr4/issues/42
-	 */
-	@Ignore("Sam's works here but mine doesn't since I fail over to LL even "
-		+ "though SLL + preds evals to single alt; i could avoid but code "
-		+ "complexity wasn't worth it. see branch SLL-w-preds-avoids-LL")
-	/* Would need to add to execDFA, execATN:
-	// IF PREDS, MIGHT RESOLVE TO SINGLE ALT => SLL (or syntax error)
-					if ( s.predicates!=null ) {
-						if ( debug ) System.out.println("DFA state has preds in DFA sim LL failover");
-						input.seek(startIndex);
-						IntervalSet alts = evalSemanticContext(s.predicates, outerContext, true);
-						if ( alts.size()==1 ) {
-							if ( debug ) System.out.println("Full LL avoided");
-							return alts.getMinElement();
-						}
-					}
 	 */
 	@Test
 	public void testPredicatedIfIfElse() throws Exception {


### PR DESCRIPTION
Evaluate predicates in SLL prediction in `execATN` before falling back to full context prediction. Avoid expensive full context prediction if unique alternative results. Resolves antlr/antlr4#42 and re-enables the associated unit test.
