### PR TITLE
Fix `USE_OF_BAD_WORD` errors

### DIFF
--- a/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
@@ -54,7 +54,7 @@ public class CodeGenPipeline {
 		idTypes.add(ANTLRParser.TOKEN_REF);
 		List<GrammarAST> idNodes = g.ast.getNodesWithType(idTypes);
 		for (GrammarAST idNode : idNodes) {
-			if ( gen.target.grammarSymbolCausesIssueInGeneratedCode(idNode.getText()) ) {
+			if ( gen.target.grammarSymbolCausesIssueInGeneratedCode(idNode) ) {
 				g.tool.errMgr.grammarError(ErrorType.USE_OF_BAD_WORD,
 										   g.fileName, idNode.getToken(),
 										   idNode.getText());

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -31,6 +31,7 @@ package org.antlr.v4.codegen;
 
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.misc.Utils;
+import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.tool.Grammar;
@@ -408,8 +409,38 @@ public class Target {
 		return getTokenTypeAsTargetLabel(gen.g, ttype);
 	}
 
-	public boolean grammarSymbolCausesIssueInGeneratedCode(String id) {
-		return badWords.contains(id);
+	public boolean grammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
+		switch (idNode.getParent().getType()) {
+		case ANTLRParser.ASSIGN:
+			switch (idNode.getParent().getParent().getType()) {
+			case ANTLRParser.ELEMENT_OPTIONS:
+			case ANTLRParser.OPTIONS:
+				return false;
+
+			default:
+				break;
+			}
+
+			break;
+
+		case ANTLRParser.AT:
+		case ANTLRParser.ELEMENT_OPTIONS:
+			return false;
+
+		case ANTLRParser.LEXER_ACTION_CALL:
+			if (idNode.getChildIndex() == 0) {
+				// first child is the command name which is part of the ANTLR language
+				return false;
+			}
+
+			// arguments to the command should be checked
+			break;
+
+		default:
+			break;
+		}
+
+		return badWords.contains(idNode.getText());
 	}
 
 }


### PR DESCRIPTION
Fix `USE_OF_BAD_WORD` getting reported for elements that never appear in the generated code, including `options{...}` blocks, the element options syntax, and lexer command names.
