### PR TITLE
Remove unused field

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
@@ -36,8 +36,7 @@ import org.antlr.v4.runtime.misc.Interval;
 public class TerminalNodeImpl implements TerminalNode {
 	public Token symbol;
 	public ParseTree parent;
-	/** Which ATN node matched this token? */
-	public int s;
+
 	public TerminalNodeImpl(Token symbol) {	this.symbol = symbol;	}
 
 	@Override


### PR DESCRIPTION
Remove unused field `TerminalNodeImpl.s`, saves at least 4 bytes per token in a parse tree!
